### PR TITLE
Add BLOCKED_RELAYS to filter out specific relay URLs

### DIFF
--- a/.github/workflows/update-relay-data.yml
+++ b/.github/workflows/update-relay-data.yml
@@ -47,6 +47,8 @@ jobs:
     - name: Update relay discovery results
       run: |
         python3 nostr_relay_discovery.py wss://relay.damus.io --output relay_discovery_results.json --batch-size 20
+      env:
+        BLOCKED_RELAYS: wss://nostr.2b9t.xyz,wss://nostr-relay.zimage.com
     
     - name: Update relay geolocation data
       run: |


### PR DESCRIPTION
This is less of a sledgehammer as https://github.com/permissionlesstech/georelays/pull/6, where specific known spammy relays can be blocked. 