### PR TITLE
Fix automated relay map generation

### DIFF
--- a/.github/workflows/relay-maps.yml
+++ b/.github/workflows/relay-maps.yml
@@ -31,11 +31,13 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install matplotlib pandas numpy folium scipy
+        # Matplotlib 3.11 raises a LinearRing error with Cartopy 0.25.0.
+        # Keep this at the last version known to render all three maps.
+        pip install matplotlib==3.10.9 pandas numpy folium scipy
         # Install cartopy and its dependencies
         sudo apt-get update
         sudo apt-get install -y libproj-dev proj-bin proj-data libgeos-dev
-        pip install cartopy
+        pip install cartopy==0.25.0
     
     - name: Generate relay maps
       run: |

--- a/scripts/generate_relay_map.py
+++ b/scripts/generate_relay_map.py
@@ -198,55 +198,35 @@ def main():
     
     # Ensure the assets directory exists
     os.makedirs('assets', exist_ok=True)
-    
-    try:
-        # Read the relay data
-        df = pd.read_csv('nostr_relays.csv')
-        
-        # Filter out rows with missing or invalid coordinates
-        df = df.dropna(subset=['Latitude', 'Longitude'])
-        
-        # Filter out invalid coordinates
-        df = df[(df['Latitude'] >= -90) & (df['Latitude'] <= 90) & 
-                (df['Longitude'] >= -180) & (df['Longitude'] <= 180)]
-        
-        # Generate maps
-        # 1. Interactive HTML map
-        relay_count_interactive = create_interactive_map(
-            df,
-            'assets/relay_locations_interactive.html'
-        )
-        
-        # 2. Static PNG map
-        try:
-            relay_count_static = create_static_map(
-                df,
-                'assets/relay_locations_static.png'
-            )
-        except Exception as e:
-            print(f"Error creating static map: {e}")
-            relay_count_static = 0
-        
-        # 3. Heatmap
-        try:
-            from scipy.ndimage import gaussian_filter
-            relay_count_heatmap = create_heatmap(
-                df,
-                'assets/relay_locations_heatmap.png'
-            )
-        except ImportError:
-            print("Could not create heatmap: scipy not installed")
-            relay_count_heatmap = 0
-            
-        # Print summary
-        print(f"Generated interactive map with {relay_count_interactive} relays")
-        if relay_count_static > 0:
-            print(f"Generated static map with {relay_count_static} relays")
-        if relay_count_heatmap > 0:
-            print(f"Generated heatmap with {relay_count_heatmap} relays")
-            
-    except Exception as e:
-        print(f"Error generating relay maps: {e}")
+
+    # Read the relay data
+    df = pd.read_csv('nostr_relays.csv')
+
+    # Filter out rows with missing or invalid coordinates
+    df = df.dropna(subset=['Latitude', 'Longitude'])
+
+    # Filter out invalid coordinates
+    df = df[(df['Latitude'] >= -90) & (df['Latitude'] <= 90) &
+            (df['Longitude'] >= -180) & (df['Longitude'] <= 180)]
+
+    # Generate maps. Any failure must propagate so CI cannot commit a partial
+    # update while reporting a successful workflow.
+    relay_count_interactive = create_interactive_map(
+        df,
+        'assets/relay_locations_interactive.html'
+    )
+    relay_count_static = create_static_map(
+        df,
+        'assets/relay_locations_static.png'
+    )
+    relay_count_heatmap = create_heatmap(
+        df,
+        'assets/relay_locations_heatmap.png'
+    )
+
+    print(f"Generated interactive map with {relay_count_interactive} relays")
+    print(f"Generated static map with {relay_count_static} relays")
+    print(f"Generated heatmap with {relay_count_heatmap} relays")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary

- pin Matplotlib 3.10.9, the last version known to work with Cartopy 0.25.0 in this workflow
- pin Cartopy 0.25.0 so the rendering environment stays reproducible
- propagate rendering errors so GitHub Actions fails instead of silently committing only the interactive map

## Root cause

The June 11 run successfully generated both PNG maps with Matplotlib 3.10.9. The first failing run on June 12 resolved Matplotlib 3.11.0 and began raising `IllegalArgumentException: Points of LinearRing do not form a closed linestring`. Because the generator caught the exception, the workflow remained green and committed only `relay_locations_interactive.html`.

## Validation

Ran the generator in a clean virtual environment with Matplotlib 3.10.9 and Cartopy 0.25.0 against the current 438-row dataset. It successfully produced:

- interactive HTML map
- 4520x2341 static PNG map
- 4520x2341 heatmap PNG

Also ran `git diff --check` and Python bytecode compilation.